### PR TITLE
Hybi00Handshake does not catch NumberFormatException

### DIFF
--- a/src/main/java/org/jboss/websockets/oio/internal/protocol/ietf00/Hybi00Handshake.java
+++ b/src/main/java/org/jboss/websockets/oio/internal/protocol/ietf00/Hybi00Handshake.java
@@ -114,7 +114,13 @@ public class Hybi00Handshake extends Handshake {
     }
 
     final String digits = encoded.replaceAll("[^0-9]", "");
-    final long product = Long.parseLong(digits);
+    final long product;
+    try {
+        product = Long.parseLong(digits);
+    }
+    catch (NumberFormatException e){
+        throw new NumberFormatException("Passed key to decode is not a parsable long");
+    }
     return product / numSpaces;
   }
 }

--- a/src/test/java/org/jboss/as/websocket/HandshakeTests.java
+++ b/src/test/java/org/jboss/as/websocket/HandshakeTests.java
@@ -14,4 +14,11 @@ public class HandshakeTests {
             "B..r..\\8".getBytes())));
   }
 
+  @Test(expected=NumberFormatException.class)
+  public void testHandshakeInvalidDecodeKey() {
+    System.out.println(new String(Hybi00Handshake.solve("MD5", Hybi00Handshake.decodeKey(""),
+            Hybi00Handshake.decodeKey(""),
+            "".getBytes())));
+  }
+
 }


### PR DESCRIPTION
Hybi00Handshake.java calls `java.lang.long.parseLong` without first
checking whether the argument parses. This 
lead to an uncaught `NumberFormateException`: [Oracle Java 7 API specification](http://docs.oracle.com/javase/7/docs/api/java/lang/Long.html#parseLong%28java.lang.String,%20int%29). 

This pull request adds a check and a test for this issue.
